### PR TITLE
Fix unresolved promise error w/ p-cancelable

### DIFF
--- a/index.js
+++ b/index.js
@@ -35,6 +35,7 @@ module.exports = ({
 		keyCombinationsOnly && '-k'
 	].filter(Boolean));
 
+	onCancel.shouldReject = false;
 	onCancel(() => {
 		resolve();
 		worker.cancel();


### PR DESCRIPTION
I don't believe the resolve on the cancel will have any effect, as the code for p-cancelable will still reject after handlers have been run.

Expecting #13 and https://github.com/karaggeorge/kap-key-cast/issues/7 to be resolved with this small change.

In commit https://github.com/sindresorhus/p-cancelable/commit/d292dcc701c41f511df97daa6e706c2601adb74e the logic was changed slightly on how canceling is handled.